### PR TITLE
README.md: tweak readme to include instructions for including csfml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ go get github.com/thinkofdeath/steven/cmd/steven
 
 To update, run `go get` with the `-u` option.
 
-Requires `csfml` libraries and headers to build.
+Requires `csfml` libraries and headers to build. To include these in your build, 
+create the following environment variables:
+
+* `CGO_CFLAGS=-Ipath/to/csfml/include`
+* `CGO_LDFLAGS=-Lpath/to/csfml/lib`
 
 ## What works
 


### PR DESCRIPTION
It should be documented, since it's a bit esoteric to be honest.