### PR TITLE
steven: changed hotbar scrolling to work like vanilla

### DIFF
--- a/desktop.go
+++ b/desktop.go
@@ -109,9 +109,9 @@ func onScroll(w *glfw.Window, xoff float64, yoff float64) {
 		Client.currentHotbarSlot--
 	}
 	if Client.currentHotbarSlot < 0 {
-		Client.currentHotbarSlot = 0
-	} else if Client.currentHotbarSlot > 8 {
 		Client.currentHotbarSlot = 8
+	} else if Client.currentHotbarSlot > 8 {
+		Client.currentHotbarSlot = 0
 	}
 
 	Client.network.Write(&protocol.HeldItemChange{Slot: int16(Client.currentHotbarSlot)})


### PR DESCRIPTION
Hey there! I've been enjoying Steven lately since it runs well on my Linux laptop, but it bothered me that the hotbar scroll functionality doesn't match vanilla, especially since I can't use numbers.

I haven't had any issues while testing it, it's just a value change.

Let me know if this is something you do or do not want in Steven.